### PR TITLE
Add Farcaster MiniApp SDK integration

### DIFF
--- a/main.go
+++ b/main.go
@@ -63,6 +63,13 @@ func homeHandler(w http.ResponseWriter, r *http.Request) {
             </div>
         </div>
     </div>
+
+    <script type="module">
+        import { sdk } from 'https://esm.sh/@farcaster/miniapp-sdk'
+        
+        // After your app is fully loaded and ready to display
+        await sdk.actions.ready()
+    </script>
 </body>
 </html>`
 	
@@ -91,3 +98,4 @@ func clickHandler(w http.ResponseWriter, r *http.Request) {
 		        hx-post="/click" hx-target="#click-counter">Click Me Again!</button>
 	</div>`, clickCount)
 }
+


### PR DESCRIPTION
## Summary
- Integrated Farcaster MiniApp SDK via CDN
- Added minimal setup with `sdk.actions.ready()` call
- Enables the Go HTMX app to run as a Farcaster miniapp

## Test plan
- [ ] Verify app loads correctly in browser
- [ ] Test that Farcaster SDK initializes properly
- [ ] Confirm splash screen is hidden after ready() call

🤖 Generated with [Claude Code](https://claude.ai/code)