### PR TITLE
Add Docker Compose configuration for easy deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+
+services:
+  app:
+    image: ghcr.io/abdullathedruid/hello-world:latest
+    ports:
+      - "8080:8080"
+    environment:
+      - ENV=production
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s


### PR DESCRIPTION
## Summary
- Add Docker Compose configuration that uses pre-built image from GHCR
- Configure health checks and restart policy for production deployment
- Map port 8080 for web access

## Test plan
- [ ] Run `docker-compose up` to verify the application starts correctly
- [ ] Verify the application is accessible on http://localhost:8080
- [ ] Test health check functionality

🤖 Generated with [Claude Code](https://claude.ai/code)