### PR TITLE
Update Docker Compose for local development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   app:
-    image: ghcr.io/abdullathedruid/hello-world:latest
+    build: .
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
## Summary
- Changed Docker Compose configuration to build from local Dockerfile instead of using pre-built image
- Replaces `image: ghcr.io/abdullathedruid/hello-world:latest` with `build: .` for easier local development

## Test plan
- [ ] Verify `docker-compose up --build` works correctly
- [ ] Confirm application starts and is accessible on port 8080
- [ ] Test that all existing functionality works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)