### PR TITLE
Replace logrus with Go's standard slog library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
 node_modules/
+
+# Go build artifacts
+hello-world
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,4 @@ module hello-world
 
 go 1.24.0
 
-require (
-	github.com/gorilla/mux v1.8.1 // indirect
-	github.com/sirupsen/logrus v1.9.3 // indirect
-	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
-)
+require github.com/gorilla/mux v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,2 @@
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
-github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/handlers/api.go
+++ b/handlers/api.go
@@ -2,12 +2,11 @@ package handlers
 
 import (
 	"html/template"
+	"log/slog"
 	"net/http"
 	"time"
 
 	"hello-world/services"
-
-	"github.com/sirupsen/logrus"
 )
 
 var clickService = services.NewClickService()
@@ -18,7 +17,7 @@ func ResetClickService() {
 }
 
 func TimeFragmentHandler(w http.ResponseWriter, r *http.Request) {
-	logrus.Info("Time endpoint accessed")
+	slog.Info("Time endpoint accessed")
 	currentTime := time.Now().Format("2006-01-02 15:04:05")
 
 	tmpl := `<div class="bg-blue-50 border border-blue-200 rounded-md p-4">
@@ -34,7 +33,7 @@ func TimeFragmentHandler(w http.ResponseWriter, r *http.Request) {
 
 func ClickFragmentHandler(w http.ResponseWriter, r *http.Request) {
 	count := clickService.IncrementClick()
-	logrus.WithField("count", count).Info("Button clicked")
+	slog.Info("Button clicked", "count", count)
 
 	tmpl := `<div class="bg-green-50 border border-green-200 rounded-md p-4">
 		<p class="text-gray-700">Button clicked <strong class="text-green-600">{{.Count}}</strong> times!</p>

--- a/handlers/debug.go
+++ b/handlers/debug.go
@@ -2,13 +2,12 @@ package handlers
 
 import (
 	"html/template"
+	"log/slog"
 	"net/http"
-
-	"github.com/sirupsen/logrus"
 )
 
 func DebugHandler(w http.ResponseWriter, r *http.Request) {
-	logrus.Info("Debug page accessed")
+	slog.Info("Debug page accessed")
 	tmpl, err := template.ParseFiles(
 		"templates/layouts/base.html",
 		"templates/pages/debug.html",

--- a/main.go
+++ b/main.go
@@ -1,17 +1,20 @@
 package main
 
 import (
+	"log/slog"
 	"net/http"
+	"os"
 
-	"github.com/sirupsen/logrus"
 	"hello-world/config"
 	"hello-world/routes"
 )
 
 func main() {
-	// Configure logrus
-	logrus.SetFormatter(&logrus.JSONFormatter{})
-	logrus.SetLevel(logrus.InfoLevel)
+	// Configure slog with JSON handler
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+	slog.SetDefault(logger)
 
 	// Load configuration
 	cfg := config.Load()
@@ -19,6 +22,9 @@ func main() {
 	// Setup routes
 	r := routes.SetupRoutes()
 
-	logrus.Info("Server starting on http://localhost:" + cfg.Port)
-	logrus.Fatal(http.ListenAndServe(":"+cfg.Port, r))
+	slog.Info("Server starting", "url", "http://localhost:"+cfg.Port)
+	if err := http.ListenAndServe(":"+cfg.Port, r); err != nil {
+		slog.Error("Server failed to start", "error", err)
+		os.Exit(1)
+	}
 }

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -1,10 +1,9 @@
 package middleware
 
 import (
+	"log/slog"
 	"net/http"
 	"time"
-
-	"github.com/sirupsen/logrus"
 )
 
 func LoggingMiddleware(next http.Handler) http.Handler {
@@ -13,10 +12,9 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r)
 
-		logrus.WithFields(logrus.Fields{
-			"method":   r.Method,
-			"path":     r.URL.Path,
-			"duration": time.Since(start),
-		}).Info("Request processed")
+		slog.Info("Request processed",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"duration", time.Since(start))
 	})
 }


### PR DESCRIPTION
## Summary
- Migrated from logrus to Go's standard `log/slog` library
- Updated all logging calls to use slog's structured key-value syntax  
- Configured JSON handler with proper error handling in main.go
- Removed external logrus dependency from go.mod
- Added Go build artifacts to .gitignore

## Benefits
- Eliminates external dependency on logrus
- Uses Go's standard library for better long-term compatibility
- Maintains same JSON logging format and functionality
- Improves error handling in main server startup

## Test plan
- [x] All existing tests pass
- [x] Application builds successfully 
- [x] No logrus references remain in codebase
- [x] Logging format remains consistent

🤖 Generated with [Claude Code](https://claude.ai/code)