### PR TITLE
Remove system info display from main page

### DIFF
--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -42,27 +42,11 @@
         </div>
     </div>
     
-    <!-- Mobile platform indicator (visible only on small screens) -->
-    <div class="mt-6 p-3 bg-gray-50 rounded-lg text-center text-xs text-gray-500 sm:hidden" id="mobile-info">
-        <span id="platform-indicator">Loading platform info...</span>
-    </div>
 </div>
 
 <script>
     // Add mobile-specific enhancements
     document.addEventListener('DOMContentLoaded', function() {
-        // Update platform indicator for mobile
-        function updatePlatformInfo() {
-            const indicator = document.getElementById('platform-indicator');
-            if (indicator) {
-                const viewport = `${window.innerWidth}×${window.innerHeight}`;
-                const platform = window.navigator.platform;
-                indicator.textContent = `${platform} • ${viewport}`;
-            }
-        }
-        
-        updatePlatformInfo();
-        window.addEventListener('resize', updatePlatformInfo);
         
         // Add touch feedback for buttons
         const buttons = document.querySelectorAll('button, a');


### PR DESCRIPTION
## Summary
- Removes the mobile platform indicator displaying "Linux aarch64 - 411x788" from the main page
- Cleans up associated JavaScript code that was detecting and displaying platform information
- Simplifies the page layout by removing unnecessary system information display

## Test plan
- [ ] Verify the main page no longer shows system platform information
- [ ] Check that page layout remains intact without the removed elements
- [ ] Confirm mobile responsiveness is unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)