### PR TITLE
Add automatic commit hash logging to server startup

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+# Environment variables for docker-compose
+# COMMIT_HASH is automatically set by Makefile targets

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ FROM golang:1.24-alpine AS go-builder
 
 WORKDIR /app
 
+# Accept build argument for commit hash
+ARG COMMIT_HASH=unknown
+
 # Copy go module files
 COPY go.mod go.sum ./
 
@@ -41,7 +44,7 @@ COPY services/ ./services/
 # Build the Go application with cache mount
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    go build -o main .
+    go build -ldflags "-X main.CommitHash=${COMMIT_HASH}" -o main .
 
 # Final stage
 FROM alpine:latest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-verbose test-coverage build run clean lint fmt vet
+.PHONY: test test-verbose test-coverage build run clean lint fmt vet docker-build docker-up docker-down docker-restart
 
 # Default target
 all: test build
@@ -61,3 +61,35 @@ check: fmt vet test bench
 deps:
 	go mod tidy
 	go mod download
+
+# Docker targets
+COMMIT_HASH := $(shell git rev-parse HEAD)
+
+# Build Docker images with commit hash
+docker-build:
+	@echo "Building with commit hash: $(COMMIT_HASH)"
+	COMMIT_HASH=$(COMMIT_HASH) docker-compose build
+
+# Start services with automatic commit hash
+docker-up:
+	@echo "Starting with commit hash: $(COMMIT_HASH)"
+	COMMIT_HASH=$(COMMIT_HASH) docker-compose up
+
+# Start services in background with automatic commit hash
+docker-up-detached:
+	@echo "Starting in background with commit hash: $(COMMIT_HASH)"
+	COMMIT_HASH=$(COMMIT_HASH) docker-compose up -d
+
+# Stop services
+docker-down:
+	docker-compose down
+
+# Restart services with latest commit hash
+docker-restart: docker-down docker-up
+
+# Rebuild and start services
+docker-rebuild: docker-build docker-up
+
+# View logs
+docker-logs:
+	docker-compose logs -f

--- a/README.md
+++ b/README.md
@@ -4,10 +4,26 @@ A well-organized Go + HTMX application following scalable architecture patterns.
 
 ## Quick Start
 
+### Local Development
 ```bash
 go build
 ./hello-world
 # Visit http://localhost:8080
+```
+
+### Docker Development
+```bash
+# Start with Docker (automatically includes commit hash in logs)
+make docker-up
+
+# Or start in background
+make docker-up-detached
+
+# Stop services
+make docker-down
+
+# Rebuild and restart
+make docker-rebuild
 ```
 
 ## Structure
@@ -29,7 +45,8 @@ go build
 - ✅ Separation of full pages vs HTMX fragments
 - ✅ Clean API routes under `/api/*`
 - ✅ Farcaster MiniApp SDK integration
-- ✅ Structured logging with Logrus
+- ✅ Structured logging with slog
+- ✅ Automatic commit hash logging in Docker deployments
 
 ## Development Workflow
 
@@ -58,6 +75,30 @@ make lint
 
 # Run all checks
 make check
+```
+
+### Docker Commands
+```bash
+# Build Docker images with current commit hash
+make docker-build
+
+# Start services (foreground)
+make docker-up
+
+# Start services (background)
+make docker-up-detached
+
+# Stop services
+make docker-down
+
+# Restart services with latest commit hash
+make docker-restart
+
+# Rebuild and start services
+make docker-rebuild
+
+# View logs
+make docker-logs
 ```
 
 ### Before Creating a Pull Request

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,10 @@ version: '3.8'
 
 services:
   app:
-    build: .
+    build:
+      context: .
+      args:
+        COMMIT_HASH: ${COMMIT_HASH:-unknown}
     ports:
       - "8080:8080"
     environment:

--- a/main.go
+++ b/main.go
@@ -9,6 +9,9 @@ import (
 	"hello-world/routes"
 )
 
+// CommitHash is set at build time via ldflags
+var CommitHash = "unknown"
+
 func main() {
 	// Configure slog with JSON handler
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
@@ -22,7 +25,7 @@ func main() {
 	// Setup routes
 	r := routes.SetupRoutes()
 
-	slog.Info("Server starting", "url", "http://localhost:"+cfg.Port)
+	slog.Info("Server starting", "url", "http://localhost:"+cfg.Port, "commit", CommitHash)
 	if err := http.ListenAndServe(":"+cfg.Port, r); err != nil {
 		slog.Error("Server failed to start", "error", err)
 		os.Exit(1)


### PR DESCRIPTION
## Summary
- Add commit hash logging to Docker deployments for easier debugging
- Integrate commit hash detection into Makefile workflow  
- Update documentation with new Docker commands

## Changes
- **Dockerfile**: Add `COMMIT_HASH` build argument with ldflags injection
- **main.go**: Log commit hash on server startup using slog
- **Makefile**: Add Docker targets with automatic commit hash detection
- **README.md**: Document new Docker workflow commands
- **docker-compose.yml**: Support commit hash build argument

## Test plan
- [x] Build Docker image with commit hash
- [x] Verify commit hash appears in server startup logs
- [x] Test Makefile targets work correctly
- [x] Update documentation

🤖 Generated with [Claude Code](https://claude.ai/code)